### PR TITLE
Fix brow/magenta colors spanning more than x_0/x^star

### DIFF
--- a/Manifestations/47-operations.Rmd
+++ b/Manifestations/47-operations.Rmd
@@ -39,12 +39,12 @@ Starting materials:
 
 i. a function $f(x)$,    
 ii. a known output value $v$, and     
-iii. a candidate for a suitable input value $\color{brown}{x_0}$
+iii. a candidate for a suitable input value ${\color{brown}x_0}$
 
-**Ideal result** from the algorithm: A new candidate $\color{magenta}{x^\star}$ such that $f(\color{magenta}{x^\star}) = v$ or, equivalently, that $$\left\|\strut f(\color{magenta}{x^\star}) - v \right\| = 0\ .$$
+**Ideal result** from the algorithm: A new candidate ${\color{magenta}x^\star}$ such that $f({\color{magenta}x^\star}) = v$ or, equivalently, that $$\left\|\strut f({\color{magenta}x^\star}) - v \right\| = 0\ .$$
 
-**Realistic result** from the algorithm: The new candidate $\color{magenta}{x^\star}$ will be better than $x_0$, that is, 
-$$ \left\|\strut f(\color{magenta}{x^\star}) - v\right\|\ \  {\mathbf <}\ \  \left\|\strut f(\color{brown}{x_0}) - v\right\|$$
+**Realistic result** from the algorithm: The new candidate ${\color{magenta}x^\star}$ will be better than $x_0$, that is, 
+$$ \left\|\strut f({\color{magenta}x^\star}) - v\right\|\ \  {\mathbf <}\ \  \left\|\strut f({\color{brown}x_0}) - v\right\|$$
 One algorithm for the operation involves approximating the function $f(x)$ with a straight-line function $\widehat{f}(x) = a x + b$. For straight-line functions, the solution $x^\star$ can be found by simple arithmetic:
 
 $$a x^\star + b - v = 0 \ \ \implies \ \ \ x^\star = \frac{b-v}{a}$$


### PR DESCRIPTION
The colors extend beyond the objects:

<img width="736" alt="Screenshot 2025-05-28 at 11 06 55" src="https://github.com/user-attachments/assets/cbe26610-fc69-49c5-97c8-be6db4cf4f4e" />

PS: Amazing resource!!